### PR TITLE
Check if a gpg key is already imported

### DIFF
--- a/images/customize.nodejs
+++ b/images/customize.nodejs
@@ -35,7 +35,7 @@ for key in \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
   ; do \
-    gpg --list-keys $key || gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+    gpg --list-keys "$key" || gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 done
 
 echo "==> Downloading package and SHASUMs from https://nodejs.org/dist/"

--- a/images/customize.nodejs
+++ b/images/customize.nodejs
@@ -35,7 +35,7 @@ for key in \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
   ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+    gpg --list-keys $key || gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 done
 
 echo "==> Downloading package and SHASUMs from https://nodejs.org/dist/"


### PR DESCRIPTION
This should speed up the build of the Node.js image a bit since the build node will typically already have the required keys